### PR TITLE
Add Docker support, GitHub actions build, update readme

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag sandwich-machine:$(date +%s)

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
 
   build:
@@ -14,5 +18,26 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Log in to the Container registry
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag sandwich-machine:$(date +%s)
+
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3-alpine
 
 WORKDIR /app
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3
+
+WORKDIR /app
+COPY . /app
+
+CMD [ "python", "./main.py" ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <p align="center">
  <h1 align="center">Sandwich Machine</h1>
+ <h5 align="center"><i>:sandwich: A generator to generate random sandwiches :sandwich:</i></h5>
 </p>
   <p align="center">
     <img src="https://img.shields.io/github/repo-size/sandwich-machine/sandwich-machine?style=for-the-badge"/>
@@ -10,13 +11,21 @@
 </p>
 
 ## How To Run
-1. Install [python](https://www.python.org/downloads/) if you haven't already.
+
+1. Install [python 3.10.4+](https://www.python.org/downloads/) if you haven't already.
 2. Double click run.bat (or run.sh if you're on mac or linux)
 
-**If you already have python installed you may need to update it to 3.10.4**
+### Docker (_multi-platform sandwiching!_) 🐳
 
-## About
-A generator to generate random sandwiches
+ℹ️ Requires [Docker](https://docs.docker.com/engine/install/)
+
+The following command will download the small docker image, and execute interactively for expedient, effective sandwich generation.
+
+`docker run -it ghcr.io/sandwich-machine/sandwich-machine:main`
+
+Subsequent runs will use the existing local image. To update, simply:
+
+`docker pull ghcr.io/sandwich-machine/sandwich-machine:main`
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@
 
 ## How To Run
 
-1. Install [python 3.10.4+](https://www.python.org/downloads/) if you haven't already.
-2. Double click run.bat (or run.sh if you're on mac or linux)
+### Traditional Install 🐍
+
+ℹ️ Requires [Python 3.10.4+](https://www.python.org/downloads/)
+
+1. Double click run.bat (or run.sh if you're on mac or linux)
 
 ### Docker (_multi-platform sandwiching!_) 🐳
 
@@ -44,3 +47,7 @@ Subsequent runs will use the existing local image. To update, simply:
 > Langs: Max, Python
 > 
 > Fun Fact: I'm a musician on soundcloud
+
+#### contributors
+
+> **[gravcat](https://github.com/gravcat) - submitted an pr that one time to containerize**


### PR DESCRIPTION
I had fun using the sandwich generator when it was shared in the free geek discord.

To maximize cross-platform sandwich capability, I added a `Dockerfile` as well as the GitHub Actions workflow stuff to make it automagically build on master, and publish the image to the repository's GitHub Packages repository.

The README.md has also been updated to include instructions for how to use the containerized distribution, should one wish. You can test this in action now before accepting this PR by testing the image sourced from my fork.

```docker run -it ghcr.io/gravcat/sandwich-machine:main```

Recommended to squash the commits during merge if accepted, so that it's merely one commit with a familiar name (the title of this MR) as opposed to several small non-descript commits.

🥪 